### PR TITLE
Add .editorconfig to .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
+^.editorconfig$
 ^README\.Rmd$
 ^README.md$
 ^README-.*\.png$


### PR DESCRIPTION
Small omission that caused an extra NOTE in the R CMD CHECK